### PR TITLE
Add SID to CSV Header

### DIFF
--- a/src/block-parser.py
+++ b/src/block-parser.py
@@ -216,7 +216,7 @@ def output_result(
     output_to_csv: bool,
 ):
     divider = "\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
-    header = "Script Block ID,Timestamp,Level,Message Total,Computer,First Message Number"
+    header = "Script Block ID,Timestamp,Level,Message Total,Computer,First Message Number,SID"
 
     if blocks:
         if output_file:


### PR DESCRIPTION
When using the -m flag and outputting metadata I noticed there was no header in place for the SID that was added. When opening in Timeline Explorer this resulted in the entire column being missing. Adding SID to the header fixes this issue.